### PR TITLE
"Module not found" issue fix

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,8 @@
 */**
 
 !package.json
+!dist/*
+!dist/**/*
 !src/index.ts
 !src/**/*
 !README.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@investigativedata/style",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Style (guide) and React components for investigativedata.io",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "@investigativedata/style",
   "version": "0.1.2",
   "description": "Style (guide) and React components for investigativedata.io",
-  "main": "./src/index.js",
-  "types": "./src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "dev": "storybook dev -p 6006",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "build": "rm -rf dist ; tsc"
   },
   "repository": {
     "type": "git",

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -28,19 +28,6 @@ export const HeroContent = ({ title, tagLine, teaser, action }: IHeroBase) => {
   );
 };
 
-export const HeroBase = ({
-  left,
-  right,
-}: {
-  left: React.ReactNode;
-  right: React.ReactNode;
-}) => (
-  <Grid container alignItems="center" alignContent="center" spacing={8}>
-    {left && <Grid md={6}>{left}</Grid>}
-    {right && <Grid md={6}>{right}</Grid>}
-  </Grid>
-);
-
 export default function Hero({
   title,
   tagLine,
@@ -49,10 +36,9 @@ export default function Hero({
   iconRight,
   action,
 }: IHeroSection) {
-  const iconSx = iconRight ? { pl: 6 } : { pr: 6 };
   const Icon = icon ? (
     <Box maxWidth="sm">
-      <OpenMoji icon={icon} sx={iconSx} />
+      <OpenMoji icon={icon} sx={{ p: 6}} />
     </Box>
   ) : null;
   const Content = (
@@ -63,7 +49,19 @@ export default function Hero({
       action={action}
     />
   );
-  const left = iconRight ? Content : Icon;
-  const right = iconRight ? Icon : Content;
-  return <HeroBase left={left} right={right} />;
+  
+  return (
+    <Grid
+      container
+      alignItems="center"
+      alignContent="center"
+      justifyContent="center"
+      spacing={8}
+      width="100%"
+      margin="0"
+    >
+      <Grid md={6} order={{ sm: 1, md: iconRight ? 2 : 1 }} >{Icon}</Grid>
+      <Grid md={6} order={{ sm: 1, md: iconRight ? 1 : 2}}>{Content}</Grid>
+    </Grid>
+  );
 }

--- a/src/sections/MediaHero.tsx
+++ b/src/sections/MediaHero.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/joy/Box";
 import type { IHeroBase } from "./Hero";
-import { HeroBase, HeroContent } from "./Hero";
+import { HeroContent } from "./Hero";
+import Grid from "@mui/joy/Grid";
 
 interface IMediaHero extends IHeroBase {
   readonly mediaComponent: React.ReactNode;
@@ -16,7 +17,7 @@ export default function MediaHero({
   action,
 }: IMediaHero) {
   const Media = (
-    <Box maxWidth="sm" justifyContent={mediaRight ? "right" : "left"}>
+    <Box maxWidth="sm">
       {mediaComponent}
     </Box>
   );
@@ -28,7 +29,18 @@ export default function MediaHero({
       action={action}
     />
   );
-  const left = mediaRight ? Content : Media;
-  const right = mediaRight ? Media : Content;
-  return <HeroBase left={left} right={right} />;
+  return (
+    <Grid
+      container
+      alignItems="center"
+      alignContent="center"
+      justifyContent="center"
+      spacing={8}
+      width="100%"
+      margin="0"
+    >
+      <Grid md={6} order={{ sm: 1, md: mediaRight ? 1 : 2 }} >{Content}</Grid>
+      <Grid md={6} order={{ sm: 1, md: mediaRight ? 2 : 1 }}>{Media}</Grid>
+    </Grid>
+  );
 }

--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -6,8 +6,8 @@ import { CardOwnerState } from "@mui/joy/Card";
 import { ChipOwnerState } from "@mui/joy/Chip";
 
 const SIZES = {
-  lg: "35px",
-  md: "24px",
+  lg: "clamp(1.5rem, 7vw, 2.5rem)",
+  md: "clamp(1rem, 7vw, 1.5rem)",
   sm: "1rem",
 };
 

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -4,7 +4,7 @@ type Typography = Partial<TypographySystemOptions>;
 
 export const typography: Typography = {
   h1: {
-    fontSize: "6rem",
+    fontSize: "clamp(2.5rem, 7vw, 6rem)",
     fontFamily: "Sligoil Micro",
     fontStyle: "normal",
     fontWeight: 400,
@@ -12,35 +12,34 @@ export const typography: Typography = {
     letterSpacing: "-0.12rem"
   },
   h2: {
-    fontSize: "4rem",
+    fontSize: "clamp(2rem, 7vw, 4rem)",
     fontStyle: "normal",
     fontWeight: 600,
     lineHeight: "120%",
     letterSpacing: "-0.04rem",
   },
   h3: {
-    fontSize: "1.5rem",
+    fontSize: "clamp(1rem, 7vw, 1.5rem)",
     fontStyle: "normal",
     fontWeight: 700,
     lineHeight: "130%",
   },
   "title-lg": {
-    fontSize: "2.5rem",
+    fontSize: "clamp(1.5rem, 7vw, 2.5rem)",
     fontStyle: "normal",
     fontWeight: 700,
     lineHeight: "130%",
     letterSpacing: "-0.05rem",
   },
   "body-lg": {
-    fontSize: "2.5rem",
+    fontSize: "clamp(1.5rem, 7vw, 2.5rem)",
     fontStyle: "normal",
     fontWeight: 500,
     lineHeight: "130%",
     letterSpacing: "-0.05rem",
   },
-  // FIXME conver to rem
   "body-md": {
-    fontSize: "24px",
+    fontSize: "clamp(1rem, 7vw, 1.5rem)",
     fontStyle: "normal",
     fontWeight: 400,
     lineHeight: "31.2px",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "declaration": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "stories/*.tsx"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [
     "node_modules",
     "build",


### PR DESCRIPTION
Addresses "module not found" issue when attempting to include this library as dependency.

- Adds new `build` script in package.json to compile and output to `dist`
- Points `main` and `types` fields in package.json to the compiled entry point

To publish to npm, the process would now be to first run `build` then `publish` (I was going to add this to the Makefile but figured I let you configure that in the way that made the most sense to you)